### PR TITLE
Use SHA-256 checksum

### DIFF
--- a/macchanger.rb
+++ b/macchanger.rb
@@ -4,7 +4,7 @@ class Macchanger < Formula
   homepage "https://github.com/acrogenesis/macchanger"
   version "1.2"
   url "https://github.com/acrogenesis/macchanger/archive/v1.2.tar.gz"
-  sha1 "86476262527eaa36955e9c2a0747fc0eca53f522"
+  sha256 "003c7c399d3ddfec4d23f271dbe5e7f0b54f8ef9db7f26d450404f6798987f3e"
 
   def install
     bin.install "bin/macchanger"


### PR DESCRIPTION
Was getting an error message when upgrading my packages:

``` bash
Warning: Calling Resource#sha1 is deprecated!
Use Resource#sha256 instead.
/usr/local/Library/Taps/acrogenesis/homebrew-macchanger/macchanger.rb:7:in `<class:Macchanger>'
Please report this to the acrogenesis/macchanger tap!
```
